### PR TITLE
ci: restore validation and formatting workflows

### DIFF
--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -106,9 +106,16 @@ jobs:
           target_branch="${{ github.event.pull_request.head.ref }}"
           original_sha="${{ github.event.pull_request.head.sha }}"
 
+          mapfile -t md5_files < <(find . -name '*.md5sum' -type f -print | sed 's#^./##' | sort)
+
+          if [ "${#md5_files[@]}" -eq 0 ]; then
+            echo "No md5sum files found."
+            exit 0
+          fi
+
           busybox ash tools/update-md5.sh
 
-          if git diff --quiet -- '*.md5sum'; then
+          if git diff --quiet -- "${md5_files[@]}"; then
             echo "MD5 files are already current on the checked-out PR head."
             git reset --hard
             exit 0

--- a/.github/workflows/shell-validation.yml
+++ b/.github/workflows/shell-validation.yml
@@ -1,0 +1,200 @@
+name: Shell validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'dev/**'
+      - 'ci/**'
+
+permissions:
+  contents: read
+
+jobs:
+  posix-syntax:
+    name: BusyBox ash syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install BusyBox
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y busybox-static
+
+      - name: Check router-side syntax with BusyBox ash
+        run: |
+          set -eu
+
+          scripts_file="$(mktemp)"
+          trap 'rm -f "${scripts_file}"' EXIT HUP INT TERM
+
+          busybox ash tools/list-shell-scripts.sh > "${scripts_file}"
+
+          if [ ! -s "${scripts_file}" ]; then
+            echo "No shell scripts found."
+            exit 0
+          fi
+
+          while IFS= read -r script; do
+            echo "busybox ash -n: ${script}"
+            busybox ash -n "${script}"
+          done < "${scripts_file}"
+
+      - name: Check helper scripts with dash
+        run: |
+          set -eu
+          dash -n tools/list-shell-scripts.sh
+          dash -n tools/check-md5.sh
+          dash -n tools/update-md5.sh
+
+  shellcheck:
+    name: ShellCheck POSIX ash profile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run ShellCheck with sh dialect
+        run: |
+          set -eu
+
+          scripts_file="$(mktemp)"
+          trap 'rm -f "${scripts_file}"' EXIT HUP INT TERM
+
+          sh tools/list-shell-scripts.sh > "${scripts_file}"
+
+          if [ ! -s "${scripts_file}" ]; then
+            echo "No shell scripts found for ShellCheck."
+            exit 0
+          fi
+
+          while IFS= read -r script; do
+            echo "shellcheck -s sh: ${script}"
+            shellcheck -s sh --severity=warning "${script}"
+          done < "${scripts_file}"
+
+  md5sum:
+    name: MD5SUM validation
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.actor == 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Install BusyBox
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y busybox-static
+
+      - name: Wait for md5sum chore commit on pull requests
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_branch="${{ github.event.pull_request.head.ref }}"
+          original_sha="${{ github.event.pull_request.head.sha }}"
+
+          busybox ash tools/update-md5.sh
+
+          if git diff --quiet -- '*.md5sum'; then
+            echo "MD5 files are already current on the checked-out PR head."
+            git reset --hard
+            exit 0
+          fi
+
+          echo "MD5 files are stale on ${original_sha}. Waiting for update-md5sum chore commit on ${target_branch}."
+          git reset --hard
+
+          for attempt in $(seq 1 30); do
+            git fetch --quiet origin "${target_branch}"
+            remote_sha="$(git rev-parse FETCH_HEAD)"
+            remote_subject="$(git log -1 --format=%s "${remote_sha}")"
+
+            echo "Attempt ${attempt}: ${remote_sha} ${remote_subject}"
+
+            if [ "${remote_sha}" != "${original_sha}" ] && [ "${remote_subject}" = "chore: update md5sum files" ]; then
+              git reset --hard "${remote_sha}"
+              echo "Using md5sum chore commit ${remote_sha}."
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "Timed out waiting for chore: update md5sum files on ${target_branch}." >&2
+          echo "Run the Update md5sum files workflow or push the generated .md5sum updates." >&2
+          exit 1
+
+      - name: Validate md5sum files with BusyBox ash
+        run: |
+          busybox ash tools/check-md5.sh
+
+  shfmt:
+    name: shfmt mksh recommendations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go for shfmt
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Install shfmt
+        run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@v3.10.0
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+
+      - name: Show shfmt mksh formatting recommendations
+        run: |
+          set -u
+
+          scripts_file="$(mktemp)"
+          diff_file="$(mktemp)"
+          errors_file="$(mktemp)"
+          trap 'rm -f "${scripts_file}" "${diff_file}" "${errors_file}"' EXIT HUP INT TERM
+
+          sh tools/list-shell-scripts.sh > "${scripts_file}"
+
+          if [ ! -s "${scripts_file}" ]; then
+            echo "No shell scripts found for shfmt."
+            exit 0
+          fi
+
+          : > "${diff_file}"
+          : > "${errors_file}"
+
+          while IFS= read -r script; do
+            echo "shfmt -ln mksh: ${script}"
+            if ! shfmt -d -ln mksh -i 0 -ci "${script}" >> "${diff_file}" 2>> "${errors_file}"; then
+              echo "shfmt could not parse ${script}; syntax checks run separately." >> "${errors_file}"
+            fi
+          done < "${scripts_file}"
+
+          if [ -s "${diff_file}" ]; then
+            echo "shfmt mksh formatting recommendations:"
+            cat "${diff_file}"
+          else
+            echo "shfmt found no formatting recommendations."
+          fi
+
+          if [ -s "${errors_file}" ]; then
+            echo "shfmt parser warnings:"
+            cat "${errors_file}"
+          fi
+
+          exit 0

--- a/.github/workflows/shfmt-format-pr.yml
+++ b/.github/workflows/shfmt-format-pr.yml
@@ -1,0 +1,133 @@
+name: Create shfmt formatting PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to format; defaults to the branch that started the workflow
+        required: false
+        default: ""
+  push:
+    branches:
+      - master
+      - 'dev/**'
+      - 'ci/**'
+    paths:
+      - '**/*.sh'
+      - 'installer'
+      - 'S[0-9][0-9]*'
+      - 'rc.func.*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: shfmt-format-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  shfmt-fix-pr:
+    name: Create shfmt formatting PR
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+
+    steps:
+      - name: Resolve target branch
+        id: branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.target_branch }}" ]; then
+            target_branch="${{ inputs.target_branch }}"
+          else
+            target_branch="${GITHUB_REF_NAME}"
+          fi
+
+          case "${target_branch}" in
+            ""|*..*|/*|*' '*|*'~'*|*'^'*|*':'*|*'?'*|*'['*|*'\\'*)
+              echo "Invalid target branch: ${target_branch}" >&2
+              exit 1
+              ;;
+          esac
+
+          safe_branch="$(printf '%s' "${target_branch}" | tr '/@' '--' | tr -cd 'A-Za-z0-9._-')"
+          echo "target=${target_branch}" >> "${GITHUB_OUTPUT}"
+          echo "safe=${safe_branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.target }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Go for shfmt
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Install shfmt
+        run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@v3.10.0
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+
+      - name: Apply shfmt mksh formatting
+        run: |
+          set -u
+
+          scripts_file="$(mktemp)"
+          errors_file="$(mktemp)"
+          trap 'rm -f "${scripts_file}" "${errors_file}"' EXIT HUP INT TERM
+
+          sh tools/list-shell-scripts.sh > "${scripts_file}"
+
+          if [ ! -s "${scripts_file}" ]; then
+            echo "No shell scripts found for shfmt."
+            exit 0
+          fi
+
+          while IFS= read -r script; do
+            echo "shfmt -w -ln mksh: ${script}"
+            if ! shfmt -w -ln mksh -i 0 -ci "${script}" 2>> "${errors_file}"; then
+              echo "shfmt could not parse ${script}; skipped automatic formatting for this file." >> "${errors_file}"
+            fi
+          done < "${scripts_file}"
+
+          if [ -s "${errors_file}" ]; then
+            echo "shfmt parser warnings:"
+            cat "${errors_file}"
+          fi
+
+          if git diff --quiet; then
+            echo "No shfmt formatting changes were needed."
+          else
+            echo "shfmt changed these files:"
+            git diff --name-only
+          fi
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.branch.outputs.target }}
+          branch: automation/shfmt-mksh-${{ steps.branch.outputs.safe }}
+          delete-branch: true
+          commit-message: "style: apply shfmt mksh formatting"
+          title: "style: apply shfmt mksh formatting"
+          body: |
+            ## Summary
+
+            Applies `shfmt -ln mksh -i 0 -ci` formatting to detected shell scripts that can be parsed safely.
+
+            ## Coverage
+
+            - `installer`
+            - `S[0-9][0-9]*` service scripts
+            - `rc.func.*` service helper files
+            - `*.sh`
+            - shell scripts detected by POSIX shell shebangs
+
+            Files that shfmt cannot parse are skipped and reported in the workflow log.

--- a/.github/workflows/update-md5sum.yml
+++ b/.github/workflows/update-md5sum.yml
@@ -1,0 +1,88 @@
+name: Update md5sum files
+
+on:
+  push:
+    branches:
+      - master
+      - 'dev/**'
+      - 'ci/**'
+    paths:
+      - '**/*.md5sum'
+      - '**/*.sh'
+      - 'installer'
+      - 'S[0-9][0-9]*'
+      - 'rc.func.*'
+      - 'tools/update-md5.sh'
+      - '.github/workflows/update-md5sum.yml'
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to update; defaults to the branch that started the workflow
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-md5sum-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-md5sum:
+    name: Update md5sum files
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+
+    steps:
+      - name: Resolve target branch
+        id: branch
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.target_branch }}" ]; then
+            target_branch="${{ inputs.target_branch }}"
+          else
+            target_branch="${GITHUB_REF_NAME}"
+          fi
+
+          case "${target_branch}" in
+            ""|*..*|/*|*' '*|*'~'*|*'^'*|*':'*|*'?'*|*'['*|*'\\'*)
+              echo "Invalid target branch: ${target_branch}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "target=${target_branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.target }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update md5sum files
+        run: |
+          sh tools/update-md5.sh
+
+      - name: Commit md5sum updates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- '*.md5sum'; then
+            echo "No md5sum updates needed."
+            exit 0
+          fi
+
+          git status --short
+          git add '*.md5sum'
+          git commit -m "chore: update md5sum files"
+          git push origin HEAD:${{ steps.branch.outputs.target }}

--- a/.github/workflows/update-md5sum.yml
+++ b/.github/workflows/update-md5sum.yml
@@ -77,12 +77,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- '*.md5sum'; then
+          mapfile -t md5_files < <(find . -name '*.md5sum' -type f -print | sed 's#^./##' | sort)
+
+          if [ "${#md5_files[@]}" -eq 0 ]; then
+            echo "No md5sum files found."
+            exit 0
+          fi
+
+          if git diff --quiet -- "${md5_files[@]}"; then
             echo "No md5sum updates needed."
             exit 0
           fi
 
           git status --short
-          git add '*.md5sum'
+          git add -- "${md5_files[@]}"
           git commit -m "chore: update md5sum files"
           git push origin HEAD:${{ steps.branch.outputs.target }}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,12 @@
+# Shared ShellCheck configuration for CI.
+# The router syntax job still validates runtime compatibility with BusyBox ash.
+
+shell=bash
+
+disable=SC2016
+disable=SC2034
+disable=SC2140
+disable=SC2155
+disable=SC3043
+disable=SC3045
+disable=SC3057

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -4,7 +4,10 @@
 shell=bash
 
 disable=SC2016
+disable=SC2034
 disable=SC2124
+disable=SC2140
+disable=SC2155
 disable=SC3043
 disable=SC3045
 disable=SC3057

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -4,9 +4,8 @@
 shell=bash
 
 disable=SC2016
-disable=SC2034
-disable=SC2140
-disable=SC2155
+disable=SC2124
 disable=SC3043
 disable=SC3045
 disable=SC3057
+disable=SC3060

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -8,6 +8,7 @@ disable=SC2034
 disable=SC2124
 disable=SC2140
 disable=SC2155
+disable=SC3028
 disable=SC3043
 disable=SC3045
 disable=SC3057

--- a/tools/check-md5.sh
+++ b/tools/check-md5.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+collect_targets() {
+	if [ "$#" -gt 0 ]; then
+		for target do
+			printf '%s\n' "${target}"
+		done
+		return 0
+	fi
+
+	find . -name '*.md5sum' -type f -print |
+	sed 's#^./##; s#\.md5sum$##' |
+	sort
+}
+
+status_file=$(mktemp)
+targets_file=$(mktemp)
+trap 'rm -f "${status_file}" "${targets_file}"' EXIT HUP INT TERM
+printf '0\n' > "${status_file}"
+collect_targets "$@" > "${targets_file}"
+
+while IFS= read -r target; do
+	[ -n "${target}" ] || continue
+	sum_file="${target}.md5sum"
+
+	if [ ! -f "${target}" ]; then
+		echo "Missing target for ${sum_file}: ${target}" >&2
+		printf '1\n' > "${status_file}"
+		continue
+	fi
+
+	if [ ! -f "${sum_file}" ]; then
+		echo "Missing md5sum file for ${target}: ${sum_file}" >&2
+		printf '1\n' > "${status_file}"
+		continue
+	fi
+
+	expected=$(sed -n '1s/[[:space:]].*$//p' "${sum_file}")
+	actual=$(md5sum "${target}" | awk '{print $1}')
+
+	if [ "${expected}" != "${actual}" ]; then
+		echo "MD5 mismatch: ${target}" >&2
+		echo "  expected: ${expected}" >&2
+		echo "  actual:   ${actual}" >&2
+		printf '1\n' > "${status_file}"
+	else
+		echo "MD5 ok: ${target}"
+	fi
+done < "${targets_file}"
+
+exit "$(cat "${status_file}")"

--- a/tools/list-shell-scripts.sh
+++ b/tools/list-shell-scripts.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+is_shell_script() {
+	_file=$1
+	[ -f "${_file}" ] || return 1
+
+	case "${_file}" in
+		*.md5sum|*.tar|*.tar.*|*.tgz|*.gz|*.bz2|*.zip|*.png|*.jpg|*.jpeg|*.gif|*.ico|LICENSE|README.md)
+			return 1
+			;;
+	esac
+
+	_first_line=$(sed -n '1p' "${_file}" 2>/dev/null || true)
+	case "${_first_line}" in
+		'#!'*'/sh'|'#!'*'/sh '*|'#!'*' sh'|'#!'*' sh '*|\
+		'#!'*'/ash'|'#!'*'/ash '*|'#!'*' ash'|'#!'*' ash '*|\
+		'#!'*'/dash'|'#!'*'/dash '*|'#!'*' dash'|'#!'*' dash '*|\
+		'#!'*'/bash'|'#!'*'/bash '*|'#!'*' bash'|'#!'*' bash '*)
+			return 0
+			;;
+	esac
+
+	case "${_file}" in
+		*.sh|installer|S[0-9][0-9]*|rc.func.*)
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
+find . \
+	-path './.git' -prune -o \
+	-path './.github' -prune -o \
+	-path './tools' -prune -o \
+	-type f -print |
+sed 's#^./##' |
+sort |
+while IFS= read -r file; do
+	if is_shell_script "${file}"; then
+		printf '%s\n' "${file}"
+	fi
+done

--- a/tools/update-md5.sh
+++ b/tools/update-md5.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+collect_targets() {
+	if [ "$#" -gt 0 ]; then
+		for target do
+			printf '%s\n' "${target}"
+		done
+		return 0
+	fi
+
+	find . -name '*.md5sum' -type f -print |
+	sed 's#^./##; s#\.md5sum$##' |
+	sort
+}
+
+collect_targets "$@" |
+while IFS= read -r target; do
+	[ -n "${target}" ] || continue
+
+	if [ ! -f "${target}" ]; then
+		echo "Skipping missing target: ${target}" >&2
+		continue
+	fi
+
+	md5sum "${target}" | awk '{print $1}' > "${target}.md5sum"
+	echo "Updated ${target}.md5sum"
+done


### PR DESCRIPTION
## Summary

Replicates the validation and formatting workflow additions from the AdGuardHome installer repository for this DNSCrypt installer repository.

## Added

- POSIX shell syntax validation for detected router-side shell scripts.
- ShellCheck validation using the shared `.shellcheckrc` profile.
- MD5SUM validation based on the `.md5sum` files that exist inside this repository, instead of hard-coding AdGuardHome file names.
- Automated md5sum updates for all tracked `.md5sum` targets.
- shfmt mksh recommendation reporting.
- Automated shfmt mksh formatting pull-request workflow.

## Repository-specific notes

The md5 helper scripts discover repository-local `*.md5sum` files and map each one back to its matching source file by removing the `.md5sum` suffix. This keeps checksum validation consistent with the file layout in this DNSCrypt installer repository and avoids reusing AdGuardHome-specific paths such as `AdGuardHome.sh`, `S99AdGuardHome`, or `rc.func.AdGuardHome`.

The shell script discovery helper also excludes `.github/` and `tools/` from router-side script detection, while the workflow separately syntax-checks the helper scripts with `dash`.