### PR TITLE
Add README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 Install, update, reconfigure, and remove [dnscrypt-proxy v2](https://github.com/jedisct1/dnscrypt-proxy) on supported ASUS routers running Asuswrt-Merlin firmware. The installer handles the router-specific setup work that is usually required when installing through Entware or similar package managers, including startup scripts and the boot-time NTP timestamp issue.
 
+## Table of contents
+
+- [Requirements](#requirements)
+- [Incompatibilities](#incompatibilities)
+- [Features](#features)
+- [Install, update, reconfigure, or uninstall](#install-update-reconfigure-or-uninstall)
+  - [Legacy dnscrypt-proxy v1](#legacy-dnscrypt-proxy-v1)
+- [Managing dnscrypt-proxy](#managing-dnscrypt-proxy)
+- [Verify that dnscrypt-proxy is running](#verify-that-dnscrypt-proxy-is-running)
+- [Troubleshooting and issue reports](#troubleshooting-and-issue-reports)
+- [Changelog](#changelog)
+- [Development checks](#development-checks)
+- [Project notes](#project-notes)
+- [Donate](#donate)
+
 ## Requirements
 
 - ASUS router running custom [Asuswrt-Merlin](https://www.asuswrt-merlin.net/) firmware.


### PR DESCRIPTION
### Motivation
- Improve README navigation by adding a Table of contents so readers can quickly jump to major sections.

### Description
- Inserted a `## Table of contents` section near the top of `README.md` with links to the repository's existing headings, including the nested `Legacy dnscrypt-proxy v1` subsection.

### Testing
- Ran a Python anchor validation script to extract headings and verify every TOC link resolves to a generated anchor, and the script reported the anchors are valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0249994830832997e7c2a14e88f70f)