### PR TITLE
Gate jitterentropy installer option until helper binary is published

### DIFF
--- a/installer
+++ b/installer
@@ -1415,16 +1415,26 @@ inst_ran_dev() {
 }
 
 inst_random() {
-	local RNG_DEV RAN_PRV
+	local RNG_DEV RAN_PRV MAX_OPTION HAS_JITTERENTROPY
 	create_dir "${TARG_DIR}"
+	HAS_JITTERENTROPY="0"
+	if http_get_file "${URL_ARCH}/jitterentropy-rngd.md5sum" "/dev/null" "" insecure; then
+		HAS_JITTERENTROPY="1"
+	fi
 	PTXT "${INFO} Install a (P)RNG for better cryptographic operations" \
 		"${INFO} Available random number generator providers:" \
 		"  1) HAVEGED (Preferred if you do not have a HW RNG)" \
-		"  2) RNGD (Preferred if you have a HW RNG)" \
-		"  3) JITTERENTROPY-RNGD (Alternative software PRNG)" \
-		"${INFO} If you choose a HW RNG, please have it plugged in now before" \
+		"  2) RNGD (Preferred if you have a HW RNG)"
+	if [ "${HAS_JITTERENTROPY}" = "1" ]; then
+		PTXT "  3) JITTERENTROPY-RNGD (Alternative software PRNG)"
+	else
+		PTXT "${WARNING} 3) JITTERENTROPY-RNGD is temporarily unavailable for this architecture."
+	fi
+	PTXT "${INFO} If you choose a HW RNG, please have it plugged in now before" \
 		"${INFO} proceeding with your selection."
-	read_input_num "Please enter the number designates your selection" 1 3
+	MAX_OPTION="2"
+	[ "${HAS_JITTERENTROPY}" = "1" ] && MAX_OPTION="3"
+	read_input_num "Please enter the number designates your selection" 1 "${MAX_OPTION}"
 	case "${CHOSEN}" in
 		1)
 			rm -f "${TARG_DIR}/rngd" "${TARG_DIR}/stty"


### PR DESCRIPTION
### Motivation

- Prevent the installer from showing the `JITTERENTROPY-RNGD` option when the architecture-specific helper binary is not yet published, which would lead to deterministic download/startup failures. 
- Improve user experience by probing artifact availability and avoiding broken choices.

### Description

- In `inst_random()` added a `HAS_JITTERENTROPY` probe using `http_get_file "${URL_ARCH}/jitterentropy-rngd.md5sum"` to detect whether the helper binary is published for the current architecture. 
- Conditionally display option `3) JITTERENTROPY-RNGD` or a warning message and set `MAX_OPTION` accordingly. 
- Updated `read_input_num` to use the dynamic `MAX_OPTION` so selection is constrained to available providers.

### Testing

- Ran `bash -n installer` to verify shell syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1375dab4cc8329b0a61b3535de694e)