### PR TITLE
Follow-up: switch armv7 nightly helper builds to uClibc-compatible toolchain

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -28,10 +28,14 @@ jobs:
         include:
           - target: linux-armv7
             repo_dir: armv7
-            host_triplet: arm-linux-gnueabihf
+            host_triplet: arm-linux-uclibcgnueabihf
+            toolchain_kind: bootlin-uclibc
+            cc_prefix: arm-buildroot-linux-uclibcgnueabihf
           - target: linux-armv8
             repo_dir: armv8
             host_triplet: aarch64-linux-gnu
+            toolchain_kind: apt
+            cc_prefix: aarch64-linux-gnu
 
     steps:
       - name: Resolve checkout ref
@@ -50,26 +54,43 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.checkout_ref }}
 
-      - name: Install cross toolchain and build deps
+      - name: Install build dependencies
         run: |
           set -eu
           sudo apt-get update
           sudo apt-get install -y \
-            autoconf automake build-essential libtool pkg-config gettext texinfo bison gawk \
-            ${{ matrix.host_triplet }} gcc-${{ matrix.host_triplet }}
+            autoconf automake build-essential libtool pkg-config gettext texinfo bison gawk curl xz-utils
+
+      - name: Install apt cross toolchain
+        if: matrix.toolchain_kind == 'apt'
+        run: |
+          set -eu
+          sudo apt-get install -y gcc-${{ matrix.host_triplet }} binutils-${{ matrix.host_triplet }}
+
+      - name: Install ASUS-compatible armv7 uClibc toolchain
+        if: matrix.toolchain_kind == 'bootlin-uclibc'
+        run: |
+          set -eu
+          mkdir -p "$HOME/.toolchains"
+          curl -fsSL \
+            https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--uclibc--stable-2017.05-1.tar.bz2 \
+            -o /tmp/armv7-uclibc-toolchain.tar.bz2
+          tar -xjf /tmp/armv7-uclibc-toolchain.tar.bz2 -C "$HOME/.toolchains"
+          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2017.05-1/bin" >> "$GITHUB_PATH"
 
       - name: Build helper binaries from source
         env:
           HOST: ${{ matrix.host_triplet }}
+          CC_PREFIX: ${{ matrix.cc_prefix }}
           OUT_DIR: dist/${{ matrix.repo_dir }}
         run: |
           set -eu
 
           mkdir -p "$OUT_DIR" _src _build
-          export CC="$HOST-gcc"
-          export AR="$HOST-ar"
-          export RANLIB="$HOST-ranlib"
-          export STRIP="$HOST-strip"
+          export CC="$CC_PREFIX-gcc"
+          export AR="$CC_PREFIX-ar"
+          export RANLIB="$CC_PREFIX-ranlib"
+          export STRIP="$CC_PREFIX-strip"
 
           build_haveged() {
             git clone --depth=1 https://github.com/jirka-h/haveged.git _src/haveged


### PR DESCRIPTION
### Motivation

- Ensure nightly armv7 helper binaries are compatible with uClibc-based ASUSWRT devices instead of producing glibc-targeted artifacts. 
- Prevent published helper binaries from failing to execute on existing armv7 routers by using a matching uClibc toolchain. 
- Allow per-target toolchain selection so armv8 builds keep using the distro `aarch64` cross toolchain while armv7 uses an ASUS-compatible toolchain.

### Description

- Change the `linux-armv7` matrix entry to use `host_triplet: arm-linux-uclibcgnueabihf` and add `toolchain_kind` and `cc_prefix` metadata. 
- Split toolchain installation into target-specific steps with an `apt` path for `aarch64` and a Bootlin-provided uClibc tarball for armv7 that is added to `GITHUB_PATH`. 
- Wire compiler tooling to the new `cc_prefix` (set `CC/AR/RANLIB/STRIP` to `$CC_PREFIX-*`) so builds invoke the correct cross toolchain. 
- Add general build deps (`curl`, `xz-utils`) and preserve the upstream source build steps and artifact publishing logic unchanged.

### Testing

- Repository inspections using `sed`, `nl`, and `rg` against `.github/workflows/build-helper-binaries-nightly.yml` completed successfully and show the new matrix and conditional install steps. 
- Basic shell-level validation of the modified workflow script (`sed`/`nl` views) succeeded in this environment. 
- An attempt to parse the workflow with a Python YAML loader failed because `PyYAML` is not installed in the running environment, so full programmatic YAML validation was not performed. 
- No GitHub Actions workflow runs were executed as part of this change; CI validation should be exercised by triggering the workflow in GitHub after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1375db2b748329b102875185e3acfe)