### PR TITLE
Follow-up: fallback to direct dnscrypt-proxy if nonroot launch fails

### DIFF
--- a/gen/manager
+++ b/gen/manager
@@ -666,22 +666,30 @@ system_time_ready() {
 
 # Service control helpers
 start_dnscrypt_proxy() {
-	local DNSCRYPT_START LOG_FACILITY
+	local LOG_FACILITY
 	{ cd /jffs/dnscrypt; } || return 1
 	if { [ "$(grep -cE '^# use_syslog = true' /jffs/dnscrypt/dnscrypt-proxy.toml)" = "1" ] && [ "$(grep -cE '^# log_file =' /jffs/dnscrypt/dnscrypt-proxy.toml)" = "5" ]; }; then LOG_FACILITY="-syslog"; fi
-	if [ -x "./nonroot" ]; then
-		DNSCRYPT_START="./nonroot ./dnscrypt-proxy ${LOG_FACILITY:+$LOG_FACILITY} -config ./dnscrypt-proxy.toml"
-	else
-		DNSCRYPT_START="./dnscrypt-proxy ${LOG_FACILITY:+$LOG_FACILITY} -config ./dnscrypt-proxy.toml"
-		logger -st "${NAME}" "Warning: /jffs/dnscrypt/nonroot is unavailable; starting dnscrypt-proxy without nonroot helper."
-	fi
 	{ kill_processes dnscrypt-proxy; }
 	if ! dnscrypt_wait_stopped 30; then
 		logger -st "${NAME}" "Warning: unable to stop existing dnscrypt-proxy processes before start."
 		return 1
 	fi
 	logger -st "${NAME}" "Starting dnscrypt-proxy from ${NAME}."
-	{ nohup ${DNSCRYPT_START} >/dev/null 2>&1 </dev/null & }
+	if [ -x "./nonroot" ]; then
+		{ nohup ./nonroot ./dnscrypt-proxy ${LOG_FACILITY:+$LOG_FACILITY} -config ./dnscrypt-proxy.toml >/dev/null 2>&1 </dev/null & }
+		if ! dnscrypt_wait_started 30; then
+			logger -st "${NAME}" "Warning: /jffs/dnscrypt/nonroot failed to start dnscrypt-proxy; retrying without nonroot helper."
+			{ kill_processes dnscrypt-proxy; }
+			if ! dnscrypt_wait_stopped 30; then
+				logger -st "${NAME}" "Warning: unable to stop failed dnscrypt-proxy processes before fallback start."
+				return 1
+			fi
+			{ nohup ./dnscrypt-proxy ${LOG_FACILITY:+$LOG_FACILITY} -config ./dnscrypt-proxy.toml >/dev/null 2>&1 </dev/null & }
+		fi
+	else
+		logger -st "${NAME}" "Warning: /jffs/dnscrypt/nonroot is unavailable; starting dnscrypt-proxy without nonroot helper."
+		{ nohup ./dnscrypt-proxy ${LOG_FACILITY:+$LOG_FACILITY} -config ./dnscrypt-proxy.toml >/dev/null 2>&1 </dev/null & }
+	fi
 	if ! grep -q '^servers-file=/jffs/dnscrypt/resolv.dnsmasq' "/etc/dnsmasq.conf"; then service restart_dnsmasq >/dev/null 2>&1; fi
 	if { dnscrypt_wait_started 30; } && { service_wait netcheck 300; }; then return 0; else return 1; fi
 }


### PR DESCRIPTION
### Motivation

- Ensure `nonroot` is a best-effort hardening helper and not a hard availability dependency for `dnscrypt-proxy` startup. 
- Avoid situations where an incompatible or broken `nonroot` executable prevents `dnscrypt-proxy` from ever starting.

### Description

- Updated `start_dnscrypt_proxy()` in `gen/manager` to attempt starting `dnscrypt-proxy` via `./nonroot` when present and to fall back to a direct `./dnscrypt-proxy` launch if the `nonroot`-spawned process does not become healthy within the existing wait window. 
- Added logging for the failure and fallback path and ensured any failed leftover processes are killed and waited-for before retrying direct start.
- Preserved the previous behavior when `nonroot` is absent (log a warning and start `./dnscrypt-proxy` directly).

### Testing

- Ran `bash -n gen/manager` to validate shell syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1375d53cb48329b15681f95e87a390)