### PR TITLE
Follow-up: ensure full uninstall always terminates jitterentropy-rngd

### DIFF
--- a/installer
+++ b/installer
@@ -1719,7 +1719,7 @@ uninst_all() {
 	if nvram get rc_support | grep -q 'mtlancfg'; then del_jffs_script /jffs/scripts/dnsmasq-sdn.postconf; fi
 	del_jffs_script /jffs/scripts/init-start
 	del_jffs_script /jffs/scripts/services-stop
-	{ kill_processes haveged rngd stty dnscrypt-proxy; }
+	{ kill_processes haveged jitterentropy-rngd rngd stty dnscrypt-proxy; }
 	del_between_magic /jffs/scripts/service-event-end '# Asuswrt-Merlin-Dnscrypt-Proxy-Installer'
 	local MAN_PID PID
 	MAN_PID="$(pidof manager)"


### PR DESCRIPTION
### Motivation

- Ensure the full uninstall path deterministically terminates the newly-introduced `jitterentropy-rngd` daemon so it cannot be left running when `dnscrypt-proxy` or manager-driven shutdown paths are skipped.

### Description

- Include `jitterentropy-rngd` in the `kill_processes` list inside `uninst_all()` in `installer` so the uninstall explicitly stops `haveged`, `jitterentropy-rngd`, `rngd`, `stty`, and `dnscrypt-proxy`.

### Testing

- Ran a syntax check with `bash -n installer` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a63834048329a0aba7df893667bf)