### PR TITLE
Follow-up: correct README armv7 helper-nightly toolchain wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The installer lets users choose either the repository-provided `dnscrypt-proxy-n
 
 The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place:
 
-- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with `arm-linux-gnueabihf`.
+- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with Bootlin uClibc toolchain prefix `arm-buildroot-linux-uclibcgnueabihf`.
 - `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with `aarch64-linux-gnu`.
 
 The workflow only commits when one or more helper binaries or checksums changed.


### PR DESCRIPTION
### Motivation

- Fix a documentation mismatch where the `Build helper-binaries-nightly` workflow actually uses a Bootlin uClibc toolchain for armv7 but the README incorrectly named `arm-linux-gnueabihf`, which could mislead contributors reproducing builds or debugging ABI/runtime differences.

### Description

- Update the README to replace `arm-linux-gnueabihf` with the Bootlin uClibc toolchain prefix `arm-buildroot-linux-uclibcgnueabihf` for the `armv7` helper-nightly entry.

### Testing

- Verified the change and repository state by running `nl -ba README.md | sed -n '160,205p'`, `git diff -- README.md`, committing with `git commit -m "docs: correct armv7 helper nightly toolchain description"`, and confirming with `nl -ba README.md | sed -n '172,182p' && git rev-parse --short HEAD`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a63256548329ba30eb85b89d1e25)