### PR TITLE
Fix Bootlin toolchain tarball name and remove duplicate git-checkout verification in nightly build workflow

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -eu
           mkdir -p "$HOME/.toolchains"
-          BOOTLIN_TARBALL="armv7-eabihf--uclibc--stable-2017.05-toolchains-1-1.tar.bz2"
+          BOOTLIN_TARBALL="armv7-eabihf--uclibc--stable-2017.05-1.tar.bz2"
           BOOTLIN_URLS="
             https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs
             https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf--uclibc--stable-2017.05-1/tarballs
@@ -135,13 +135,6 @@ jobs:
                 && ! git fetch --depth=1 origin "refs/tags/$fallback_ref" \
                 && ! git fetch --depth=1 origin "refs/heads/$fallback_ref"; then
                 echo "Failed to fetch pinned ref $repo_ref (and fallback $fallback_ref) from $repo_url" >&2
-                exit 1
-              fi
-            fi
-            git checkout --detach FETCH_HEAD
-            if printf '%s' "$repo_ref" | grep -Eq '^[0-9a-f]{40}$'; then
-              if [ "$(git rev-parse HEAD)" != "$repo_ref" ]; then
-                echo "Resolved revision for $repo_url did not match pinned ref $repo_ref" >&2
                 exit 1
               fi
             fi


### PR DESCRIPTION
### Motivation
- Ensure the nightly build workflow can download the correct Bootlin armv7 uClibc toolchain tarball and avoid redundant repository checkout checks that could be confusing or error-prone.

### Description
- Update the `BOOTLIN_TARBALL` filename to `armv7-eabihf--uclibc--stable-2017.05-1.tar.bz2` so the workflow matches available Bootlin tarball names.
- Remove a duplicated `git checkout --detach FETCH_HEAD` and commit-hash verification block inside `clone_repo_at_ref` to eliminate redundant logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e3619c08329842653d05616dabe)