### PR TITLE
Update Bootlin armv7-uClibc toolchain to 2025.08 and make haveged build more robust

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -72,16 +72,15 @@ jobs:
         run: |
           set -eu
           mkdir -p "$HOME/.toolchains"
-          BOOTLIN_TARBALL="armv7-eabihf--uclibc--stable-2017.05-1.tar.bz2"
+          BOOTLIN_TARBALL="armv7-eabihf--uclibc--stable-2025.08-1.tar.xz"
           BOOTLIN_URLS="
             https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs
-            https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf--uclibc--stable-2017.05-1/tarballs
           "
 
           for base_url in $BOOTLIN_URLS; do
-            if curl -fsSL "$base_url/$BOOTLIN_TARBALL" -o /tmp/armv7-uclibc-toolchain.tar.bz2; then
-              curl -fsSL "$base_url/$BOOTLIN_TARBALL.sha256" -o /tmp/armv7-uclibc-toolchain.tar.bz2.sha256
-              (cd /tmp && sha256sum -c armv7-uclibc-toolchain.tar.bz2.sha256)
+            if curl -fsSL "$base_url/$BOOTLIN_TARBALL" -o /tmp/armv7-uclibc-toolchain.tar.xz; then
+              curl -fsSL "$base_url/$BOOTLIN_TARBALL.sha256" -o /tmp/armv7-uclibc-toolchain.tar.xz.sha256
+              (cd /tmp && sha256sum -c armv7-uclibc-toolchain.tar.xz.sha256)
               found_url="$base_url"
               break
             fi
@@ -91,8 +90,8 @@ jobs:
             echo "Unable to download $BOOTLIN_TARBALL from known Bootlin URLs" >&2
             exit 1
           fi
-          tar -xjf /tmp/armv7-uclibc-toolchain.tar.bz2 -C "$HOME/.toolchains"
-          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2017.05-1/bin" >> "$GITHUB_PATH"
+          tar -xJf /tmp/armv7-uclibc-toolchain.tar.xz -C "$HOME/.toolchains"
+          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2025.08-1/bin" >> "$GITHUB_PATH"
 
       - name: Build helper binaries from source
         env:
@@ -151,7 +150,11 @@ jobs:
           build_haveged() {
             clone_repo_at_ref "$HAVEGED_REPO" "$HAVEGED_REF" _src/haveged
             cd _src/haveged
-            ./autogen.sh
+            autoreconf -i || {
+              if [ ! -f configure ]; then
+                autoconf
+              fi
+            }
             ./configure --host="$HOST" --prefix=/usr
             make -j"$(nproc)"
             cp haveged/.libs/haveged "${GITHUB_WORKSPACE}/${OUT_DIR}/haveged"


### PR DESCRIPTION
### Motivation

- Move to a newer Bootlin armv7-eabihf uClibc toolchain release that uses an `.xz` tarball and update extraction and path accordingly.
- Make the `haveged` build resilient to repositories that provide `configure` via `autoreconf` by falling back to `autoconf` if needed.

### Description

- Replace `BOOTLIN_TARBALL` with `armv7-eabihf--uclibc--stable-2025.08-1.tar.xz` and update the Bootlin URL list to remove the old hardcoded 2017 path.  
- Update download and checksum handling to use `.tar.xz` filenames and verify the `.sha256` file before extraction.  
- Change extraction command from `tar -xjf` to `tar -xJf` and update the exported toolchain path written to `GITHUB_PATH` to the `2025.08-1` directory.  
- Replace `./autogen.sh` in `build_haveged` with `autoreconf -i` and add a fallback that runs `autoconf` if no `configure` script is present.  

### Testing

- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152182e3188329a5943fd86a380b3a)