### PR TITLE
ci: move helper nightly builds to native ARM runners

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -21,21 +21,19 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: linux-armv7
             repo_dir: armv7
-            host_triplet: arm-linux-uclibcgnueabihf
-            toolchain_kind: bootlin-uclibc
-            cc_prefix: arm-buildroot-linux-uclibcgnueabihf
+            host_triplet: arm-linux-gnueabihf
+            runs_on: [self-hosted, linux, armv7]
           - target: linux-armv8
             repo_dir: armv8
             host_triplet: aarch64-linux-gnu
-            toolchain_kind: apt
-            cc_prefix: aarch64-linux-gnu
+            runs_on: [self-hosted, linux, arm64]
 
     steps:
       - name: Resolve checkout ref
@@ -61,42 +59,18 @@ jobs:
           sudo apt-get install -y \
             autoconf automake build-essential libtool pkg-config gettext texinfo bison gawk curl xz-utils
 
-      - name: Install apt cross toolchain
-        if: matrix.toolchain_kind == 'apt'
-        run: |
-          set -eu
-          sudo apt-get install -y gcc-${{ matrix.host_triplet }} binutils-${{ matrix.host_triplet }}
-
-      - name: Install ASUS-compatible armv7 uClibc toolchain
-        if: matrix.toolchain_kind == 'bootlin-uclibc'
-        run: |
-          set -eu
-          mkdir -p "$HOME/.toolchains"
-          BOOTLIN_TARBALL='armv7-eabihf--uclibc--stable-2025.08-1.tar.xz'
-          BOOTLIN_URL='https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/'
-          if curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}" -o /tmp/armv7-uclibc-toolchain.tar.xz; then
-              curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}.sha256" -o /tmp/armv7-uclibc-toolchain.tar.xz.sha256
-              (cd /tmp && sha256sum -c armv7-uclibc-toolchain.tar.xz.sha256)
-          else
-            echo "Unable to download ${BOOTLIN_TARBALL} from known Bootlin URLs" >&2
-            exit 1
-          fi
-          tar -xJf /tmp/armv7-uclibc-toolchain.tar.xz -C "$HOME/.toolchains"
-          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2025.08-1/bin" >> "$GITHUB_PATH"
-
       - name: Build helper binaries from source
         env:
           HOST: ${{ matrix.host_triplet }}
-          CC_PREFIX: ${{ matrix.cc_prefix }}
           OUT_DIR: dist/${{ matrix.repo_dir }}
         run: |
           set -eu
 
           mkdir -p "$OUT_DIR" _src _build
-          export CC="$CC_PREFIX-gcc"
-          export AR="$CC_PREFIX-ar"
-          export RANLIB="$CC_PREFIX-ranlib"
-          export STRIP="$CC_PREFIX-strip"
+          export CC="gcc"
+          export AR="ar"
+          export RANLIB="ranlib"
+          export STRIP="strip"
 
           HAVEGED_REPO="https://github.com/jirka-h/haveged.git"
           HAVEGED_REF="21bad00a09233855fbea14ac062bc72b5eabc9a6"

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ The workflow derives and publishes the matching public key as `gen/dnscrypt-prox
 
 The installer lets users choose either the repository-provided `dnscrypt-proxy-nightly` package or the developer latest release package during install/update. The nightly build uses Go cross-compilation with `CGO_ENABLED=0`; Asuswrt-Merlin.ng toolchains are still appropriate for C helper binaries, but they are not required for dnscrypt-proxy unless the intention is to enable cgo.
 
-The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place:
+The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place. The workflow now uses native self-hosted build environments for each target architecture instead of external cross-toolchains:
 
-- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with Bootlin uClibc toolchain prefix `arm-buildroot-linux-uclibcgnueabihf`.
-- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with `aarch64-linux-gnu`.
+- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on a native `self-hosted/linux/armv7` runner.
+- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on a native `self-hosted/linux/arm64` runner.
 
 The workflow only commits when one or more helper binaries or checksums changed.
 


### PR DESCRIPTION
### Motivation
- Reduce reliance on externally provisioned cross-toolchains by running helper-binaries nightly builds on architecture-native runners.
- Simplify CI provisioning and use the toolchains already available on native ARM hosts for more reliable native builds.

### Description
- Updated `.github/workflows/build-helper-binaries-nightly.yml` to run matrix jobs on per-architecture self-hosted runners by setting `runs-on: ${{ matrix.runs_on }}` and adding `runs_on: [self-hosted, linux, armv7]` for `linux-armv7` and `runs_on: [self-hosted, linux, arm64]` for `linux-armv8`.
- Removed external cross-toolchain provisioning steps (Bootlin uClibc tarball download and apt cross-toolchain installs) from the workflow.
- Switched build tool environment variables in the workflow to use native toolchain commands by exporting `CC="gcc"`, `AR="ar"`, `RANLIB="ranlib"`, and `STRIP="strip"` instead of prefixed cross-toolchain binaries.
- Updated `README.md` text to document that helper binaries are now built on native `self-hosted` ARM runners rather than via cross-compilation toolchains.

### Testing
- Ran `git diff -- .github/workflows/build-helper-binaries-nightly.yml README.md` to verify the workflow and documentation changes, which showed the intended edits and succeeded. 
- Committed changes with `git commit -m "ci: build nightly helpers on native arm runners"`, which completed successfully. 
- Inspected the updated files with `nl -ba .github/workflows/build-helper-binaries-nightly.yml` and `nl -ba README.md` to confirm matrix and README updates, which produced the expected output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15391384548329a3047b7f21eb8c16)