### PR TITLE
build(helper-binaries): switch armv7 to distro cross-toolchains and simplify workflow

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -28,13 +28,11 @@ jobs:
         include:
           - target: linux-armv7
             repo_dir: armv7
-            host_triplet: arm-linux-uclibcgnueabihf
-            toolchain_kind: bootlin-uclibc
-            cc_prefix: arm-buildroot-linux-uclibcgnueabihf
+            host_triplet: arm-linux-gnueabihf
+            cc_prefix: arm-linux-gnueabihf
           - target: linux-armv8
             repo_dir: armv8
             host_triplet: aarch64-linux-gnu
-            toolchain_kind: apt
             cc_prefix: aarch64-linux-gnu
 
     steps:
@@ -61,28 +59,11 @@ jobs:
           sudo apt-get install -y \
             autoconf automake build-essential libtool pkg-config gettext texinfo bison gawk curl xz-utils
 
-      - name: Install apt cross toolchain
-        if: matrix.toolchain_kind == 'apt'
+
+      - name: Install cross toolchain
         run: |
           set -eu
           sudo apt-get install -y gcc-${{ matrix.host_triplet }} binutils-${{ matrix.host_triplet }}
-
-      - name: Install ASUS-compatible armv7 uClibc toolchain
-        if: matrix.toolchain_kind == 'bootlin-uclibc'
-        run: |
-          set -eu
-          mkdir -p "$HOME/.toolchains"
-          BOOTLIN_TARBALL='armv7-eabihf--uclibc--stable-2025.08-1.tar.xz'
-          BOOTLIN_URL='https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/'
-          if curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}" -o /tmp/armv7-uclibc-toolchain.tar.xz; then
-              curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}.sha256" -o /tmp/armv7-uclibc-toolchain.tar.xz.sha256
-              (cd /tmp && sha256sum -c armv7-uclibc-toolchain.tar.xz.sha256)
-          else
-            echo "Unable to download ${BOOTLIN_TARBALL} from known Bootlin URLs" >&2
-            exit 1
-          fi
-          tar -xJf /tmp/armv7-uclibc-toolchain.tar.xz -C "$HOME/.toolchains"
-          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2025.08-1/bin" >> "$GITHUB_PATH"
 
       - name: Build helper binaries from source
         env:

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ The workflow derives and publishes the matching public key as `gen/dnscrypt-prox
 
 The installer lets users choose either the repository-provided `dnscrypt-proxy-nightly` package or the developer latest release package during install/update. The nightly build uses Go cross-compilation with `CGO_ENABLED=0`; Asuswrt-Merlin.ng toolchains are still appropriate for C helper binaries, but they are not required for dnscrypt-proxy unless the intention is to enable cgo.
 
-The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place:
+The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place using an Ubuntu build environment with per-target cross-toolchains:
 
-- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with Bootlin uClibc toolchain prefix `arm-buildroot-linux-uclibcgnueabihf`.
-- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with `aarch64-linux-gnu`.
+- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on `ubuntu-latest` using `arm-linux-gnueabihf` toolchain packages.
+- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on `ubuntu-latest` using `aarch64-linux-gnu` toolchain packages.
 
 The workflow only commits when one or more helper binaries or checksums changed.
 


### PR DESCRIPTION
### Motivation

- Simplify cross-toolchain management for the nightly helper binaries by using Ubuntu package-provided toolchains instead of downloading a Bootlin tarball.  
- Unify installation steps across matrix targets to reduce conditional logic and maintenance burden.  
- Update documentation to describe the new build environment and toolchain package names.

### Description

- Change the `linux-armv7` matrix `host_triplet` from `arm-linux-uclibcgnueabihf` to `arm-linux-gnueabihf` and set `cc_prefix` to `arm-linux-gnueabihf`.  
- Remove the `toolchain_kind` matrix variant and the separate conditional steps that downloaded and extracted a Bootlin uClibc tarball.  
- Replace the Bootlin download logic with a unified `Install cross toolchain` step that runs `sudo apt-get install -y gcc-${{ matrix.host_triplet }} binutils-${{ matrix.host_triplet }}`.  
- Update `README.md` to reflect that helper binaries are built on `ubuntu-latest` using distro toolchain packages and adjust example toolchain prefixes in the docs.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15391384548329a3047b7f21eb8c16)