### PR TITLE
Use Debian cross toolchains and harden cross-build steps in helper-binaries nightly workflow

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -28,14 +28,14 @@ jobs:
         include:
           - target: linux-armv7
             repo_dir: armv7
-            host_triplet: arm-linux-uclibcgnueabihf
-            toolchain_kind: bootlin-uclibc
-            cc_prefix: arm-buildroot-linux-uclibcgnueabihf
+            host_triplet: arm-linux-gnueabihf
+            cc_prefix: arm-linux-gnueabihf
+            deb_arch: armhf
           - target: linux-armv8
             repo_dir: armv8
             host_triplet: aarch64-linux-gnu
-            toolchain_kind: apt
             cc_prefix: aarch64-linux-gnu
+            deb_arch: arm64
 
     steps:
       - name: Resolve checkout ref
@@ -57,32 +57,20 @@ jobs:
       - name: Install build dependencies
         run: |
           set -eu
+          sudo dpkg --add-architecture ${{ matrix.deb_arch }}
           sudo apt-get update
           sudo apt-get install -y \
             autoconf automake build-essential libtool pkg-config gettext texinfo bison gawk curl xz-utils
 
-      - name: Install apt cross toolchain
-        if: matrix.toolchain_kind == 'apt'
+
+      - name: Install cross toolchain
         run: |
           set -eu
           sudo apt-get install -y gcc-${{ matrix.host_triplet }} binutils-${{ matrix.host_triplet }}
-
-      - name: Install ASUS-compatible armv7 uClibc toolchain
-        if: matrix.toolchain_kind == 'bootlin-uclibc'
-        run: |
-          set -eu
-          mkdir -p "$HOME/.toolchains"
-          BOOTLIN_TARBALL='armv7-eabihf--uclibc--stable-2025.08-1.tar.xz'
-          BOOTLIN_URL='https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/'
-          if curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}" -o /tmp/armv7-uclibc-toolchain.tar.xz; then
-              curl -fsSL -H "User-Agent: Mozilla/5.0" "${BOOTLIN_URL}${BOOTLIN_TARBALL}.sha256" -o /tmp/armv7-uclibc-toolchain.tar.xz.sha256
-              (cd /tmp && sha256sum -c armv7-uclibc-toolchain.tar.xz.sha256)
-          else
-            echo "Unable to download ${BOOTLIN_TARBALL} from known Bootlin URLs" >&2
-            exit 1
-          fi
-          tar -xJf /tmp/armv7-uclibc-toolchain.tar.xz -C "$HOME/.toolchains"
-          echo "$HOME/.toolchains/armv7-eabihf--uclibc--stable-2025.08-1/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y \
+            pkg-config \
+            libcurl4-openssl-dev:${{ matrix.deb_arch }} \
+            libxml2-dev:${{ matrix.deb_arch }}
 
       - name: Build helper binaries from source
         env:
@@ -97,6 +85,7 @@ jobs:
           export AR="$CC_PREFIX-ar"
           export RANLIB="$CC_PREFIX-ranlib"
           export STRIP="$CC_PREFIX-strip"
+          export PKG_CONFIG_LIBDIR="/usr/lib/${HOST}/pkgconfig:/usr/share/pkgconfig"
 
           HAVEGED_REPO="https://github.com/jirka-h/haveged.git"
           HAVEGED_REF="21bad00a09233855fbea14ac062bc72b5eabc9a6"
@@ -141,17 +130,19 @@ jobs:
           build_haveged() {
             clone_repo_at_ref "$HAVEGED_REPO" "$HAVEGED_REF" _src/haveged
             cd _src/haveged
-            autoreconf -i || {
-              if [ ! -f configure ]; then
-                autoconf
-              fi
-            }
-            ./configure --host="$HOST" --prefix=/usr
+            autoreconf -fiv
+            ./configure \
+              --build="$(gcc -dumpmachine)" \
+              --host="$HOST" \
+              --prefix=/usr \
+              CC="$CC" AR="$AR" RANLIB="$RANLIB" STRIP="$STRIP"
             make -j"$(nproc)" || {
-              echo "haveged build failed" >&2
+              echo "haveged parallel build failed; retrying single-threaded" >&2
               make clean
-              make  # Try single-threaded build for better error diagnostics
-              exit 1
+              make || {
+                echo "haveged build failed" >&2
+                exit 1
+              }
             }
 
             # Check multiple possible binary locations
@@ -176,7 +167,13 @@ jobs:
             clone_repo_at_ref "$RNG_TOOLS_REPO" "$RNG_TOOLS_REF" _src/rng-tools
             cd _src/rng-tools
             ./autogen.sh
-            ./configure --host="$HOST" --prefix=/usr --disable-silent-rules
+            ./configure \
+              --build="$(gcc -dumpmachine)" \
+              --host="$HOST" \
+              --prefix=/usr \
+              --disable-silent-rules \
+              CC="$CC" AR="$AR" RANLIB="$RANLIB" STRIP="$STRIP" \
+              PKG_CONFIG=pkg-config
             make -j"$(nproc)"
             cp rngd "${GITHUB_WORKSPACE}/${OUT_DIR}/rngd"
             cd "${GITHUB_WORKSPACE}"

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ The workflow derives and publishes the matching public key as `gen/dnscrypt-prox
 
 The installer lets users choose either the repository-provided `dnscrypt-proxy-nightly` package or the developer latest release package during install/update. The nightly build uses Go cross-compilation with `CGO_ENABLED=0`; Asuswrt-Merlin.ng toolchains are still appropriate for C helper binaries, but they are not required for dnscrypt-proxy unless the intention is to enable cgo.
 
-The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place:
+The `Build helper-binaries-nightly` workflow also runs nightly (cron `37 7 * * *`) and supports manual `Run workflow` execution with the same `target_branch` input behavior. It compiles installer helper binaries from upstream source repositories on every run (rather than extracting prebuilt package blobs), then updates checksums in-place using an Ubuntu build environment with per-target cross-toolchains:
 
-- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with Bootlin uClibc toolchain prefix `arm-buildroot-linux-uclibcgnueabihf`.
-- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, cross-compiled with `aarch64-linux-gnu`.
+- `armv7/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on `ubuntu-latest` using `arm-linux-gnueabihf` toolchain packages.
+- `armv8/{haveged,rngd,jitterentropy-rngd,stty,nonroot}` + matching `.md5sum` files, built on `ubuntu-latest` using `aarch64-linux-gnu` toolchain packages.
 
 The workflow only commits when one or more helper binaries or checksums changed.
 


### PR DESCRIPTION
### Motivation

- Replace the custom Bootlin uClibc toolchain flow with standard Debian cross-toolchain packages to simplify the build environment and improve reproducibility.
- Ensure correct pkg-config search paths and explicit tool variables for reliable cross-compilation of helper binaries.

### Description

- Updated `.github/workflows/build-helper-binaries-nightly.yml` to use `arm-linux-gnueabihf` for `linux-armv7` and added `deb_arch` entries (`armhf`/`arm64`) in the matrix.
- Add `sudo dpkg --add-architecture ${{ matrix.deb_arch }}` and install cross compilers via `apt` (`gcc-${{ matrix.host_triplet }}` and `binutils-${{ matrix.host_triplet }}`) and target-arch dev packages (`libcurl4-openssl-dev:${{ matrix.deb_arch }}`, `libxml2-dev:${{ matrix.deb_arch }}`).
- Remove Bootlin tarball download logic and the `toolchain_kind` branching, and set `PKG_CONFIG_LIBDIR` to include `/usr/lib/${HOST}/pkgconfig` for cross `pkg-config` resolution.
- Hardened build steps for `haveged` and `rng-tools` by adding `--build=$(gcc -dumpmachine)`, explicit `CC/AR/RANLIB/STRIP` in `./configure`, improved `autoreconf` flags, set `PKG_CONFIG=pkg-config`, and added a single-threaded `make` retry with clearer diagnostics.
- Updated `README.md` to reflect the new Ubuntu-package-based cross-toolchain approach and adjusted the workflow description accordingly.

### Testing

- Validated the workflow YAML syntax and basic CI configuration locally and via GitHub Actions syntax checks which completed successfully.
- No repository unit tests were modified; changes are limited to CI/workflow and build scripts so no runtime unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15391384548329a3047b7f21eb8c16)