### PR TITLE
Replace Coreutils-based stty build with small C stty helper in nightly workflow

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -18,10 +18,6 @@ concurrency:
   group: helper-binaries-nightly-${{ inputs.target_branch || github.ref_name }}
   cancel-in-progress: true
 
-env:
-  COREUTILS_VERSION: "9.11"
-  COREUTILS_CACHE_REV: "1"
-
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -102,7 +98,7 @@ jobs:
 
           ${{ matrix.cc_prefix }}-gcc --version
           ${{ matrix.cc_prefix }}-ld --version
-          
+
       - name: Build helper binaries from source
         env:
           HOST: ${{ matrix.host_triplet }}
@@ -170,8 +166,6 @@ jobs:
           LIBP11_REPO="https://github.com/OpenSC/libp11.git"
           LIBP11_REF="master"
 
-          COREUTILS_VERSION="9.11"
-          COREUTILS_SHA256_BASE64="OUAk7aCllVIXztqc0SAeZdyPo6opwpURNaSVIdV8PMM="
 
           clone_repo_at_ref() {
             repo_url="$1"
@@ -299,7 +293,7 @@ jobs:
 
             pkg-config --modversion openssl
             pkg-config --cflags --libs openssl
-          }          
+          }
 
           build_eudev() {
             clone_repo_at_ref "$EUDEV_REPO" "$EUDEV_REF" _src/eudev
@@ -808,7 +802,7 @@ jobs:
               find . -name 'jitterentropy*.h' -print
               exit 1
             fi
-            
+
             # Try to extract a version from the header; fall back safely.
             JENT_VERSION="$(
               grep -E '#define[[:space:]]+JENT_VERSION' "$DEPS_DIR/include/jitterentropy.h" 2>/dev/null \
@@ -941,7 +935,7 @@ jobs:
             pkg-config --cflags libcap
             pkg-config --libs libcap
           }
-          
+
           build_all_rng_dependencies() {
             build_zlib
             build_openssl
@@ -1111,170 +1105,266 @@ jobs:
           }
 
           build_stty() {
-            : "${COREUTILS_VERSION:?COREUTILS_VERSION is not set}"
-            : "${COREUTILS_SHA256_BASE64:?COREUTILS_SHA256_BASE64 is not set}"
+            mkdir -p "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/$OUT_DIR"
 
-            url="https://ftp.gnu.org/gnu/coreutils/coreutils-${COREUTILS_VERSION}.tar.xz"
-            out="$GITHUB_WORKSPACE/_build/coreutils-${COREUTILS_VERSION}.tar.xz"
-            srcdir="$GITHUB_WORKSPACE/_src/coreutils-${COREUTILS_VERSION}"
-            logdir="$GITHUB_WORKSPACE/_build/coreutils-${COREUTILS_VERSION}-logs"
-            final_stty="$GITHUB_WORKSPACE/$OUT_DIR/stty"
+            src="$GITHUB_WORKSPACE/_build/stty.c"
+            out="$GITHUB_WORKSPACE/$OUT_DIR/stty"
 
-            mkdir -p "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/_src" "$logdir" "$GITHUB_WORKSPACE/$OUT_DIR"
+            cat > "$src" <<'STTY_C'
+          #include <errno.h>
+          #include <fcntl.h>
+          #include <stdio.h>
+          #include <stdlib.h>
+          #include <string.h>
+          #include <termios.h>
+          #include <unistd.h>
 
-            if [ -x "$srcdir/src/stty" ]; then
-              echo "Using existing Coreutils stty: $srcdir/src/stty"
-              cp -v "$srcdir/src/stty" "$final_stty"
-              "$STRIP" "$final_stty" 2>/dev/null || true
-              chmod 0755 "$final_stty"
-              file "$final_stty" || true
-              return 0
-            fi
+          struct speed_entry {
+            const char *name;
+            speed_t value;
+          };
 
-            rm -rf "$srcdir"
-            rm -f "$out"
+          static const struct speed_entry speeds[] = {
+          #ifdef B0
+            {"0", B0},
+          #endif
+          #ifdef B50
+            {"50", B50},
+          #endif
+          #ifdef B75
+            {"75", B75},
+          #endif
+          #ifdef B110
+            {"110", B110},
+          #endif
+          #ifdef B134
+            {"134", B134},
+          #endif
+          #ifdef B150
+            {"150", B150},
+          #endif
+          #ifdef B200
+            {"200", B200},
+          #endif
+          #ifdef B300
+            {"300", B300},
+          #endif
+          #ifdef B600
+            {"600", B600},
+          #endif
+          #ifdef B1200
+            {"1200", B1200},
+          #endif
+          #ifdef B1800
+            {"1800", B1800},
+          #endif
+          #ifdef B2400
+            {"2400", B2400},
+          #endif
+          #ifdef B4800
+            {"4800", B4800},
+          #endif
+          #ifdef B9600
+            {"9600", B9600},
+          #endif
+          #ifdef B19200
+            {"19200", B19200},
+          #endif
+          #ifdef B38400
+            {"38400", B38400},
+          #endif
+          #ifdef B57600
+            {"57600", B57600},
+          #endif
+          #ifdef B115200
+            {"115200", B115200},
+          #endif
+          #ifdef B230400
+            {"230400", B230400},
+          #endif
+          #ifdef B460800
+            {"460800", B460800},
+          #endif
+          #ifdef B500000
+            {"500000", B500000},
+          #endif
+          #ifdef B576000
+            {"576000", B576000},
+          #endif
+          #ifdef B921600
+            {"921600", B921600},
+          #endif
+          #ifdef B1000000
+            {"1000000", B1000000},
+          #endif
+          #ifdef B1152000
+            {"1152000", B1152000},
+          #endif
+          #ifdef B1500000
+            {"1500000", B1500000},
+          #endif
+          #ifdef B2000000
+            {"2000000", B2000000},
+          #endif
+          #ifdef B2500000
+            {"2500000", B2500000},
+          #endif
+          #ifdef B3000000
+            {"3000000", B3000000},
+          #endif
+          #ifdef B3500000
+            {"3500000", B3500000},
+          #endif
+          #ifdef B4000000
+            {"4000000", B4000000},
+          #endif
+          };
 
-            echo "Downloading coreutils: $url"
-            curl -fL --retry 5 --retry-delay 3 "$url" -o "$out"
-
-            echo "Verifying coreutils base64 SHA256:"
-            python3 -c 'import base64, hashlib, sys; p=sys.argv[1]; exp=sys.argv[2]; data=open(p,"rb").read(); got=base64.b64encode(hashlib.sha256(data).digest()).decode(); print(f"{p}: {got}"); sys.exit(0 if got == exp else 1)' "$out" "$COREUTILS_SHA256_BASE64"
-
-            tar -xf "$out" -C "$GITHUB_WORKSPACE/_src"
-
-            cd "$srcdir"
-
-            echo "Configuring Coreutils for $HOST"
-
-            # Execute directly to prevent pipeline redirection status masking
-            ./configure \
-              --build="$(gcc -dumpmachine)" \
-              --host="$HOST" \
-              --prefix=/usr \
-              --without-selinux \
-              --disable-acl \
-              --disable-xattr \
-              --disable-nls \
-              CC="$CC" \
-              AR="$AR" \
-              RANLIB="$RANLIB" \
-              STRIP="$STRIP" \
-              CPPFLAGS="$COMMON_CPPFLAGS" \
-              CFLAGS="$COMMON_CFLAGS" \
-              LDFLAGS="$COMMON_LDFLAGS -static" \
-              > "$logdir/configure.log" 2>&1
-            
-            CONF_EXIT=$?
-            if [ $CONF_EXIT -ne 0 ]; then
-              echo "CRITICAL ERROR: Coreutils configure failed with exit code $CONF_EXIT!" >&2
-              echo "=== DISPLAYING LAST 200 LINES OF config.log ===" >&2
-              if [ -f config.log ]; then
-                tail -n 200 config.log >&2
-              else
-                tail -n 200 "$logdir/configure.log" >&2
-              fi
-              echo "===============================================" >&2
-              exit 1
-            fi
-
-            echo "Building Coreutils internal library dependencies (Parallel)"
-
-            make V=1 -j"$(nproc)" -C lib \
-              CC="$CC" \
-              AR="$AR" \
-              RANLIB="$RANLIB" \
-              STRIP="$STRIP" \
-              CPPFLAGS="$COMMON_CPPFLAGS" \
-              CFLAGS="$COMMON_CFLAGS" \
-              LDFLAGS="$COMMON_LDFLAGS -static" \
-              > "$logdir/build-coreutils-lib.log" 2>&1
-            
-            BUILD_LIB_EXIT=$?
-            if [ $BUILD_LIB_EXIT -eq 0 ]; then
-              echo "Coreutils lib parallel build failed (Exit: $BUILD_LIB_EXIT). Printing logs and retrying single-threaded..." >&2
-              echo "=== PARALLEL LIB BUILD LOG TAIL ===" >&2
-              tail -n 240 "$logdir/build-coreutils-lib.log" >&2 || true
-              echo "===================================" >&2
-
-              echo "Building Coreutils internal library dependencies (Single-Threaded)"
-              make V=1 -j1 -C lib \
-                CC="$CC" \
-                AR="$AR" \
-                RANLIB="$RANLIB" \
-                STRIP="$STRIP" \
-                CPPFLAGS="$COMMON_CPPFLAGS" \
-                CFLAGS="$COMMON_CFLAGS" \
-                LDFLAGS="$COMMON_LDFLAGS -static" \
-                > "$logdir/build-coreutils-lib-single.log" 2>&1
-              
-              BUILD_LIB_SINGLE_EXIT=$?
-              if [ $BUILD_LIB_SINGLE_EXIT -eq 0 ]; then
-                echo "CRITICAL ERROR: Coreutils lib single-threaded build failed (Exit: $BUILD_LIB_SINGLE_EXIT)!" >&2
-                echo "=== SINGLE-THREADED LIB BUILD LOG TAIL ===" >&2
-                tail -n 300 "$logdir/build-coreutils-lib-single.log" >&2 || true
-                echo "==========================================" >&2
-                exit 1
-              fi
-            fi
-
-            echo "Building only Coreutils stty (Parallel)"
-
-            make V=1 -j"$(nproc)" -C src \
-              CC="$CC" \
-              AR="$AR" \
-              RANLIB="$RANLIB" \
-              STRIP="$STRIP" \
-              CPPFLAGS="$COMMON_CPPFLAGS -I.. -I../lib -I." \
-              CFLAGS="$COMMON_CFLAGS" \
-              LDFLAGS="$COMMON_LDFLAGS -static" \
-              stty \
-              > "$logdir/build-stty.log" 2>&1
-            
-            BUILD_STTY_EXIT=$?
-            if [ $BUILD_STTY_EXIT -eq 0 ]; then
-              echo "Coreutils stty parallel build failed (Exit: $BUILD_STTY_EXIT). Printing logs and retrying single-threaded..." >&2
-              echo "=== PARALLEL STTY BUILD LOG TAIL ===" >&2
-              tail -n 240 "$logdir/build-stty.log" >&2 || true
-              echo "====================================" >&2
-
-              echo "Building only Coreutils stty (Single-Threaded)"
-              make V=1 -j1 -C src \
-                CC="$CC" \
-                AR="$AR" \
-                RANLIB="$RANLIB" \
-                STRIP="$STRIP" \
-                CPPFLAGS="$COMMON_CPPFLAGS -I.. -I../lib -I." \
-                CFLAGS="$COMMON_CFLAGS" \
-                LDFLAGS="$COMMON_LDFLAGS -static" \
-                stty \
-                > "$logdir/build-stty-single.log" 2>&1
-              
-              BUILD_STTY_SINGLE_EXIT=$?
-              if [ $BUILD_STTY_SINGLE_EXIT -eq 0 ]; then
-                echo "CRITICAL ERROR: Coreutils stty single-threaded build failed (Exit: $BUILD_STTY_SINGLE_EXIT)!" >&2
-                echo "=== SINGLE-THREADED STTY BUILD LOG TAIL ===" >&2
-                tail -n 300 "$logdir/build-stty-single.log" >&2 || true
-                echo "===========================================" >&2
-                exit 1
-              fi
-            fi
-
-            if [ ! -f "src/stty" ]; then
-              echo "CRITICAL ERROR: src/stty was not created despite build completing!" >&2
-              echo "Coreutils logs are in: $logdir" >&2
-              find . -name 'stty' -type f -print
-              exit 1
-            fi
-
-            cp -v src/stty "$final_stty"
-            "$STRIP" "$final_stty" 2>/dev/null || true
-            chmod 0755 "$final_stty"
-            file "$final_stty" || true
-
-            echo "Successfully built and packaged stty target."
-            cd "$GITHUB_WORKSPACE"
+          static void usage(const char *program) {
+            fprintf(stderr, "Usage: %s [-F DEVICE] [raw] [-echo] [-ixoff] [speed BAUD]\n", program);
           }
-          
+
+          static int parse_speed(const char *text, speed_t *speed) {
+            size_t i;
+
+            for (i = 0; i < sizeof(speeds) / sizeof(speeds[0]); i++) {
+              if (strcmp(text, speeds[i].name) == 0) {
+                *speed = speeds[i].value;
+                return 0;
+              }
+            }
+
+            return -1;
+          }
+
+          static void make_raw(struct termios *term) {
+            term->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+            term->c_oflag &= ~OPOST;
+            term->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG);
+          #ifdef IEXTEN
+            term->c_lflag &= ~IEXTEN;
+          #endif
+            term->c_cflag &= ~(CSIZE | PARENB);
+            term->c_cflag |= CS8;
+            term->c_cc[VMIN] = 1;
+            term->c_cc[VTIME] = 0;
+          }
+
+          int main(int argc, char **argv) {
+            const char *device = NULL;
+            int fd = STDIN_FILENO;
+            struct termios term;
+            int i;
+
+            for (i = 1; i < argc; i++) {
+              if (strcmp(argv[i], "-F") == 0 || strcmp(argv[i], "--file") == 0) {
+                if (++i >= argc) {
+                  fprintf(stderr, "%s: missing device after %s\n", argv[0], argv[i - 1]);
+                  usage(argv[0]);
+                  return 64;
+                }
+                device = argv[i];
+              } else if (strncmp(argv[i], "--file=", 7) == 0) {
+                device = argv[i] + 7;
+              } else if (strcmp(argv[i], "speed") == 0) {
+                if (++i >= argc) {
+                  fprintf(stderr, "%s: missing baud rate after speed\n", argv[0]);
+                  usage(argv[0]);
+                  return 64;
+                }
+              }
+            }
+
+            if (device) {
+              fd = open(device, O_RDWR | O_NOCTTY | O_NONBLOCK);
+              if (fd < 0) {
+                fprintf(stderr, "%s: failed to open %s: %s\n", argv[0], device, strerror(errno));
+                return 66;
+              }
+            }
+
+            if (tcgetattr(fd, &term) != 0) {
+              fprintf(stderr, "%s: tcgetattr failed: %s\n", argv[0], strerror(errno));
+              if (device) close(fd);
+              return 66;
+            }
+
+            for (i = 1; i < argc; i++) {
+              if (strcmp(argv[i], "-F") == 0 || strcmp(argv[i], "--file") == 0) {
+                i++;
+              } else if (strncmp(argv[i], "--file=", 7) == 0) {
+                continue;
+              } else if (strcmp(argv[i], "raw") == 0) {
+                make_raw(&term);
+              } else if (strcmp(argv[i], "-echo") == 0) {
+                term.c_lflag &= ~ECHO;
+              } else if (strcmp(argv[i], "echo") == 0) {
+                term.c_lflag |= ECHO;
+              } else if (strcmp(argv[i], "-ixoff") == 0) {
+                term.c_iflag &= ~IXOFF;
+              } else if (strcmp(argv[i], "ixoff") == 0) {
+                term.c_iflag |= IXOFF;
+              } else if (strcmp(argv[i], "-ixon") == 0) {
+                term.c_iflag &= ~IXON;
+              } else if (strcmp(argv[i], "ixon") == 0) {
+                term.c_iflag |= IXON;
+              } else if (strcmp(argv[i], "speed") == 0) {
+                speed_t speed;
+
+                if (++i >= argc) {
+                  fprintf(stderr, "%s: missing baud rate after speed\n", argv[0]);
+                  usage(argv[0]);
+                  if (device) close(fd);
+                  return 64;
+                }
+
+                if (parse_speed(argv[i], &speed) != 0) {
+                  fprintf(stderr, "%s: unsupported baud rate: %s\n", argv[0], argv[i]);
+                  if (device) close(fd);
+                  return 65;
+                }
+
+                if (cfsetispeed(&term, speed) != 0 || cfsetospeed(&term, speed) != 0) {
+                  fprintf(stderr, "%s: failed to set speed %s: %s\n", argv[0], argv[i], strerror(errno));
+                  if (device) close(fd);
+                  return 66;
+                }
+              } else {
+                fprintf(stderr, "%s: unsupported setting: %s\n", argv[0], argv[i]);
+                usage(argv[0]);
+                if (device) close(fd);
+                return 64;
+              }
+            }
+
+            if (tcsetattr(fd, TCSANOW, &term) != 0) {
+              fprintf(stderr, "%s: tcsetattr failed: %s\n", argv[0], strerror(errno));
+              if (device) close(fd);
+              return 66;
+            }
+
+            if (device) close(fd);
+
+            return 0;
+          }
+          STTY_C
+
+            echo "Building stty compatibility helper for $HOST"
+
+            "$CC" \
+              ${COMMON_CPPFLAGS:-} \
+              ${COMMON_CFLAGS:-} \
+              "$src" \
+              ${COMMON_LDFLAGS:-} \
+              -o "$out"
+
+            "$STRIP" "$out" 2>/dev/null || true
+
+            chmod 0755 "$out"
+
+            file "$out" || true
+          }
+
           build_nonroot() {
             mkdir -p "$GITHUB_WORKSPACE/_build" "$GITHUB_WORKSPACE/$OUT_DIR"
 
@@ -1334,7 +1424,7 @@ jobs:
 
             file "$out" || true
           }
-          
+
           build_jitterentropy_rngd() {
             clone_repo_at_ref "$JITTERENTROPY_REPO" "$JITTERENTROPY_REF" _src/jitterentropy-rngd
 


### PR DESCRIPTION
### Motivation
- Avoid downloading and building the entire GNU Coreutils package just to produce `stty`, reducing CI time and external dependencies.
- Remove pinned `COREUTILS_VERSION` and related checksum variables that are no longer required for the helper build.
- Improve cross-compilation reliability by building a small, self-contained `stty` implementation targeted by the existing cross toolchain.

### Description
- Removed `COREUTILS_VERSION`/`COREUTILS_CACHE_REV`/`COREUTILS_SHA256_BASE64` environment variables and their usages from the workflow.
- Replaced the original `build_stty` logic that downloaded and built Coreutils with a routine that generates `stty.c` and compiles it with the cross-compiler into `dist/<repo_dir>/stty`.
- Added a portable `stty.c` implementation that parses device and option arguments, maps baud rates to `termios` speeds, applies term settings via `tcgetattr`/`tcsetattr`, and returns sensible exit codes; the compiled binary is stripped and `chmod`ed like other helper binaries.
- Applied minor formatting and syntax fixes (whitespace and brace alignment) in the workflow script.

### Testing
- Ran the modified nightly build workflow locally using `act` for the `linux-armv7` and `linux-armv8` matrix and confirmed that `stty` and `nonroot` binaries are built, stripped, and present in the `dist` output (success).
- Validated the workflow YAML and shell fragments with `yamllint` and `bash -n` syntax checks, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a191e1fec908329ae09c5ecdf069b0c)