### PR TITLE
Fix helper-binaries nightly publish to push to target branch

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -1544,23 +1544,30 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
-      - name: Resolve checkout ref
-        id: ref
+      - name: Resolve publish branch
+        id: branch
         run: |
           set -eu
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.target_branch }}" ]; then
-            checkout_ref="${{ inputs.target_branch }}"
+            publish_branch="${{ inputs.target_branch }}"
           else
-            checkout_ref="${{ github.sha }}"
+            publish_branch="${{ github.ref_name }}"
           fi
 
-          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
+          case "${publish_branch}" in
+            ""|*..*|/*|*' '*|*'~'*|*'^'*|*':'*|*'?'*|*'['*|*'\'*)
+              echo "Invalid publish branch: ${publish_branch}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "publish_branch=${publish_branch}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout installer repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.ref.outputs.checkout_ref }}
+          ref: ${{ steps.branch.outputs.publish_branch }}
 
       - name: Download helper binary artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -1612,4 +1619,4 @@ jobs:
           fi
 
           git commit -m "chore: update helper binaries nightly builds"
-          git push
+          git push origin HEAD:${{ steps.branch.outputs.publish_branch }}


### PR DESCRIPTION
### Motivation
- The publish job could checkout a detached `SHA` for scheduled runs and then attempt to push without a branch target, which causes the update to fail. 
- The workflow needs to resolve and validate a real branch name to ensure scheduled and manual runs update the intended branch.

### Description
- Update `.github/workflows/build-helper-binaries-nightly.yml` to resolve a `publish_branch` from the `workflow_dispatch` `target_branch` input or `github.ref_name` instead of using the triggering `SHA`.
- Add validation for the `publish_branch` value to reject invalid branch names.
- Checkout the installer repository using the resolved `publish_branch` output and ensure the publish step targets that branch when pushing changes by using `HEAD:<publish_branch>` as the push target.
- Rename the step id to `branch` and wire outputs accordingly so the publish flow checks out and updates the intended branch.

### Testing
- Ran a `python3` assertion script to verify the updated publish branch wiring and push target were present and correct, which passed. 
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-helper-binaries-nightly.yml")'` to validate YAML syntax, which succeeded. 
- Executed `git diff --check` to ensure no whitespace or diff issues, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19397489b08329b9351ab7689df496)