### PR TITLE
Fix coreutils stty generated header build

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -1140,7 +1140,6 @@ jobs:
               --disable-acl \
               --disable-nls \
               --disable-xattr \
-              --without-gmp \
               --without-openssl \
               CC="$CC" \
               AR="$AR" \
@@ -1150,6 +1149,9 @@ jobs:
               CFLAGS="$COMMON_CFLAGS" \
               LDFLAGS="$COMMON_LDFLAGS"
 
+            # Building the leaf target directly can skip generated headers that
+            # the full coreutils build would create first.
+            make V=1 lib/configmake.h
             make V=1 src/stty
 
             cp -v src/stty "$GITHUB_WORKSPACE/$OUT_DIR/stty"


### PR DESCRIPTION
### Motivation
- The workflow builds the leaf `src/stty` target directly which can skip generated headers (the build failed with `configmake.h: No such file or directory`) and the configure step warned about an unsupported `--without-gmp` option.

### Description
- Remove the unsupported `--without-gmp` configure flag from the coreutils `stty` build in `.github/workflows/build-helper-binaries-nightly.yml`.
- Add an explicit `make V=1 lib/configmake.h` before `make V=1 src/stty` so the generated header is created prior to building the leaf target.

### Testing
- Ran `bash -n /tmp/build_stty_snippet.sh`, which succeeded.
- Ran `git diff --check`, which reported no whitespace or diff issues.
- Attempted to parse the workflow YAML via Python using `PyYAML`, which failed because `PyYAML` is not installed in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a60e1088c832984cb5feaa9d647b6)