### PR TITLE
workflows: build coreutils stty with gnu11 CFLAGS and remove --without-gmp

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -1134,20 +1134,23 @@ jobs:
 
             echo "Building GNU coreutils stty ${COREUTILS_VERSION} for $HOST"
 
+            # Keep coreutils stty on a pre-C23 GNU dialect for older cross
+            # compilers; gnulib supplies the needed fallbacks under GNU11.
+            coreutils_stty_cflags="-std=gnu11 -Os -fdata-sections -ffunction-sections"
+
             FORCE_UNSAFE_CONFIGURE=1 ./configure \
               --host="$HOST" \
               --prefix=/usr \
               --disable-acl \
               --disable-nls \
               --disable-xattr \
-              --without-gmp \
               --without-openssl \
               CC="$CC" \
               AR="$AR" \
               RANLIB="$RANLIB" \
               STRIP="$STRIP" \
               CPPFLAGS="$COMMON_CPPFLAGS" \
-              CFLAGS="$COMMON_CFLAGS" \
+              CFLAGS="$coreutils_stty_cflags" \
               LDFLAGS="$COMMON_LDFLAGS"
 
             make V=1 src/stty


### PR DESCRIPTION
### Motivation

- Ensure the `stty` helper binary is built with a pre-C23 GNU dialect so older cross compilers can compile it reliably.
- Avoid potential missing fallback behavior by explicitly using GNU11 which `gnulib` can supplement.

### Description

- Add a new `coreutils_stty_cflags` variable set to `-std=gnu11 -Os -fdata-sections -ffunction-sections` and use it for `CFLAGS` when configuring coreutils' `stty` build.
- Replace usage of the shared `COMMON_CFLAGS` with the new `coreutils_stty_cflags` for the `stty` target.
- Remove the `--without-gmp` configure flag from the coreutils `stty` build invocation.
- Preserve the existing build steps including `./configure`, `make V=1 src/stty`, stripping, and file pattern validation.

### Testing

- Ran the modified nightly workflow that builds `stty` and confirmed the `make V=1 src/stty` step completed without errors.
- Verified the produced `stty` binary was copied, stripped, and its type matched the expected pattern stored in `$STTY_FILE_PATTERN`.
- No other automated tests were changed or run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a60e1088c832984cb5feaa9d647b6)