### PR TITLE
Align nightly stty helper build with Entware coreutils

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -169,7 +169,9 @@ jobs:
           LIBP11_REPO="https://github.com/OpenSC/libp11.git"
           LIBP11_REF="master"
 
-          COREUTILS_VERSION="9.11"
+          # Match Entware's coreutils package baseline for the standalone stty helper.
+          COREUTILS_VERSION="9.9"
+          COREUTILS_HASH="19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75"
 
           clone_repo_at_ref() {
             repo_url="$1"
@@ -1127,6 +1129,8 @@ jobs:
               exit 1
             }
 
+            printf '%s  %s\n' "$COREUTILS_HASH" "$coreutils_tar" | sha256sum -c -
+
             rm -rf "$coreutils_src"
             tar -xf "$coreutils_tar" -C "$GITHUB_WORKSPACE/_src"
 
@@ -1134,17 +1138,37 @@ jobs:
 
             echo "Building GNU coreutils stty ${COREUTILS_VERSION} for $HOST"
 
-            # Keep coreutils stty on a pre-C23 GNU dialect for older cross
-            # compilers; gnulib supplies the needed fallbacks under GNU11.
-            coreutils_stty_cflags="-std=gnu11 -Os -fdata-sections -ffunction-sections"
+            # Entware builds coreutils with GNU17 plus gnulib cache answers that
+            # avoid target runtime probes during cross-compilation. Keep those
+            # stty-relevant settings, but do not enable ACL/libcap because this
+            # workflow builds only src/stty instead of the complete applet set.
+            coreutils_stty_cflags="-std=gnu17 $COMMON_CFLAGS"
 
-            FORCE_UNSAFE_CONFIGURE=1 ./configure \
+            FORCE_UNSAFE_CONFIGURE=1 \
+            gl_cv_func_mbrtowc_incomplete_state=yes \
+            gl_cv_func_mbrtowc_retval=yes \
+            gl_cv_func_wcrtomb_retval=yes \
+            ac_cv_header_selinux_context_h=no \
+            ac_cv_header_selinux_flash_h=no \
+            ac_cv_header_selinux_selinux_h=no \
+            ac_cv_search_setfilecon=no \
+            ac_cv_sys_year2038_opts="none needed" \
+            ./configure \
+              --build="$(gcc -dumpmachine)" \
               --host="$HOST" \
               --prefix=/usr \
               --disable-acl \
               --disable-nls \
               --disable-xattr \
+              --enable-threads=posix \
+              --disable-assert \
+              --disable-rpath \
+              --disable-libsmack \
+              --without-gmp \
+              --without-linux-crypto \
               --without-openssl \
+              --without-selinux \
+              --without-included-regex \
               CC="$CC" \
               AR="$AR" \
               RANLIB="$RANLIB" \


### PR DESCRIPTION
### Motivation
- Produce a standalone `stty` helper that matches Entware's build baseline and cross-build behavior so the nightly helper artifacts behave like Entware-provided `stty`.
- Improve supply-chain safety by pinning the coreutils source baseline and verifying the downloaded tarball before extraction.

### Description
- Pin `COREUTILS_VERSION` to `9.9` and add `COREUTILS_HASH` for the expected tarball SHA-256; verify the tarball with `sha256sum -c` before extracting. 
- Adjust the `stty` build to use Entware-style cross-build cache answers and environment (set `gl_*`/`ac_cv_*` vars) and switch to GNU17 CFLAGS via `coreutils_stty_cflags="-std=gnu17 $COMMON_CFLAGS"` for compatibility with Entware assumptions. 
- Add configure options used by Entware (`--build`, `--enable-threads=posix`, `--without-gmp`, `--without-linux-crypto`, `--without-selinux`, `--without-included-regex`, etc.) while keeping `--disable-acl`/`--disable-nls`/`--disable-xattr` to avoid pulling in full coreutils applet dependencies. 
- Continue building only the generated prerequisites plus the leaf `src/stty` target, then `strip` and `chmod` the artifact and validate its type against `STTY_FILE_PATTERN` as before. 

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-helper-binaries-nightly.yml")'` which returned successfully. 
- Performed syntax checks with `bash -n` on the extracted `Build helper binaries from source` step script and on all embedded step scripts which completed without errors. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b6b5e518483299c961087f79238c6)