### PR TITLE
Produce static helper binaries and build only coreutils stty with verification

### DIFF
--- a/.github/workflows/build-helper-binaries-nightly.yml
+++ b/.github/workflows/build-helper-binaries-nightly.yml
@@ -140,6 +140,7 @@ jobs:
           export COMMON_CFLAGS="-Os -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables -fno-unwind-tables -D_FORTIFY_SOURCE=2"
           export COMMON_CXXFLAGS="$COMMON_CFLAGS"
           export COMMON_LDFLAGS="-L$DEPS_DIR/lib -L$DEPS_DIR/lib64 -Wl,--gc-sections -Wl,-z,relro -Wl,-z,now"
+          export STATIC_LDFLAGS="-static $COMMON_LDFLAGS"
 
           HAVEGED_REPO="https://github.com/jirka-h/haveged.git"
           HAVEGED_REF="21bad00a09233855fbea14ac062bc72b5eabc9a6"
@@ -169,7 +170,13 @@ jobs:
           LIBP11_REPO="https://github.com/OpenSC/libp11.git"
           LIBP11_REF="master"
 
-          COREUTILS_VERSION="9.11"
+          # Match Entware's coreutils package baseline for the standalone stty helper.
+          COREUTILS_VERSION="9.9"
+          COREUTILS_HASH="19bcb6ca867183c57d77155eae946c5eced88183143b45ca51ad7d26c628ca75"
+          # Entware lists stty in COREUTILS_APPLETS and DIR_BIN, then its
+          # BuildPlugin installs the applet from opt/bin/stty. Build exactly
+          # that applet target instead of the full coreutils package set.
+          COREUTILS_APPLET="stty"
 
           clone_repo_at_ref() {
             repo_url="$1"
@@ -208,6 +215,27 @@ jobs:
             fi
 
             cd "$GITHUB_WORKSPACE"
+          }
+
+
+          assert_static_binary() {
+            binary_path="$1"
+            binary_name="$2"
+
+            echo "Checking ${binary_name} is statically linked"
+            file "$binary_path"
+
+            if "$READELF" -l "$binary_path" | grep -q 'INTERP'; then
+              echo "${binary_name} is dynamically linked: ELF interpreter was found" >&2
+              "$READELF" -l "$binary_path" >&2 || true
+              exit 1
+            fi
+
+            if "$READELF" -d "$binary_path" 2>/dev/null | grep -q '(NEEDED)'; then
+              echo "${binary_name} is dynamically linked: shared library dependencies were found" >&2
+              "$READELF" -d "$binary_path" >&2 || true
+              exit 1
+            fi
           }
 
           build_zlib() {
@@ -977,7 +1005,7 @@ jobs:
               STRIP="$STRIP" \
               CPPFLAGS="$COMMON_CPPFLAGS" \
               CFLAGS="$COMMON_CFLAGS" \
-              LDFLAGS="$COMMON_LDFLAGS"
+              LDFLAGS="$STATIC_LDFLAGS"
 
             make -j"$(nproc)" || {
               echo "haveged parallel build failed; retrying single-threaded" >&2
@@ -1037,7 +1065,7 @@ jobs:
             done
 
             RNGD_CPPFLAGS="$COMMON_CPPFLAGS"
-            RNGD_LDFLAGS="$COMMON_LDFLAGS"
+            RNGD_LDFLAGS="$STATIC_LDFLAGS"
 
             RNGD_PKG_CFLAGS="$(
               pkg-config --cflags \
@@ -1127,6 +1155,8 @@ jobs:
               exit 1
             }
 
+            printf '%s  %s\n' "$COREUTILS_HASH" "$coreutils_tar" | sha256sum -c -
+
             rm -rf "$coreutils_src"
             tar -xf "$coreutils_tar" -C "$GITHUB_WORKSPACE/_src"
 
@@ -1134,17 +1164,37 @@ jobs:
 
             echo "Building GNU coreutils stty ${COREUTILS_VERSION} for $HOST"
 
-            # Keep coreutils stty on a pre-C23 GNU dialect for older cross
-            # compilers; gnulib supplies the needed fallbacks under GNU11.
-            coreutils_stty_cflags="-std=gnu11 -Os -fdata-sections -ffunction-sections"
+            # Entware builds coreutils with GNU17 plus gnulib cache answers that
+            # avoid target runtime probes during cross-compilation. Keep those
+            # stty-relevant settings, but do not enable ACL/libcap because this
+            # workflow builds only the stty applet instead of the complete
+            # applet set that Entware splits through BuildPlugin.
+            coreutils_stty_cflags="-std=gnu17 $COMMON_CFLAGS"
 
-            FORCE_UNSAFE_CONFIGURE=1 ./configure \
+            FORCE_UNSAFE_CONFIGURE=1 \
+            gl_cv_func_mbrtowc_incomplete_state=yes \
+            gl_cv_func_mbrtowc_retval=yes \
+            gl_cv_func_wcrtomb_retval=yes \
+            ac_cv_header_selinux_context_h=no \
+            ac_cv_header_selinux_flash_h=no \
+            ac_cv_header_selinux_selinux_h=no \
+            ac_cv_search_setfilecon=no \
+            ac_cv_sys_year2038_opts="none needed" \
+            ./configure \
+              --build="$(gcc -dumpmachine)" \
               --host="$HOST" \
               --prefix=/usr \
               --disable-acl \
               --disable-nls \
               --disable-xattr \
+              --enable-threads=posix \
+              --disable-assert \
+              --disable-rpath \
+              --disable-libsmack \
+              --without-linux-crypto \
               --without-openssl \
+              --without-selinux \
+              --without-included-regex \
               CC="$CC" \
               AR="$AR" \
               RANLIB="$RANLIB" \
@@ -1153,12 +1203,17 @@ jobs:
               CFLAGS="$coreutils_stty_cflags" \
               LDFLAGS="$COMMON_LDFLAGS"
 
-            # Building the leaf target directly can skip generated headers that
-            # the full coreutils build would create first.
-            make V=1 lib/configmake.h
-            make V=1 src/stty
+            # Building an explicit applet target does not trigger Automake's
+            # BUILT_SOURCES set, so build the generated headers/sources first
+            # without building the full coreutils applet set.
+            {
+              printf '%s\n' 'build-generated-sources: $(BUILT_SOURCES)'
+              printf '%s\n' '.PHONY: build-generated-sources'
+            } > "$GITHUB_WORKSPACE/_build/coreutils-built-sources.mk"
+            make V=1 -f Makefile -f "$GITHUB_WORKSPACE/_build/coreutils-built-sources.mk" build-generated-sources
+            make V=1 "src/$COREUTILS_APPLET"
 
-            cp -v src/stty "$GITHUB_WORKSPACE/$OUT_DIR/stty"
+            cp -v "src/$COREUTILS_APPLET" "$GITHUB_WORKSPACE/$OUT_DIR/stty"
             "$STRIP" "$GITHUB_WORKSPACE/$OUT_DIR/stty" 2>/dev/null || true
             chmod 0755 "$GITHUB_WORKSPACE/$OUT_DIR/stty"
 
@@ -1244,8 +1299,8 @@ jobs:
             # Passing COMMON_CFLAGS here would inject -Os and trip jitterentropy's
             # compile-time safety check on both ARM targets.
             JENT_RNGD_CPPFLAGS="-D_GNU_SOURCE -I$DEPS_DIR/include -I. -Ilib"
-            JENT_RNGD_CFLAGS="-O0 -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fPIE -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables -fno-unwind-tables"
-            JENT_RNGD_LDFLAGS="$COMMON_LDFLAGS -pie -lrt -pthread"
+            JENT_RNGD_CFLAGS="-O0 -fwrapv --param ssp-buffer-size=4 -fvisibility=hidden -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables -fno-unwind-tables"
+            JENT_RNGD_LDFLAGS="$STATIC_LDFLAGS -lrt -pthread"
 
             echo "Building jitterentropy-rngd for $HOST"
             echo "JENT_RNGD_CPPFLAGS=$JENT_RNGD_CPPFLAGS"
@@ -1312,6 +1367,10 @@ jobs:
             "$OUT_DIR/stty" \
             "$OUT_DIR/nonroot" \
             "$OUT_DIR/jitterentropy-rngd"
+
+          assert_static_binary "$OUT_DIR/haveged" haveged
+          assert_static_binary "$OUT_DIR/rngd" rngd
+          assert_static_binary "$OUT_DIR/jitterentropy-rngd" jitterentropy-rngd
 
           md5sum "$OUT_DIR/haveged" | awk '{print $1}' > "$OUT_DIR/haveged.md5sum"
           md5sum "$OUT_DIR/rngd" | awk '{print $1}' > "$OUT_DIR/rngd.md5sum"


### PR DESCRIPTION
### Motivation

- Ensure helper binaries produced by the nightly workflow are statically linked so they are portable to target systems.
- Match Entware's packaging by building exactly the `stty` applet instead of the full GNU coreutils package and pin an Entware-aligned coreutils baseline.
- Add integrity checks and cross-compilation cache answers to make the cross-build reproducible and to fail early on tampered or unexpected tarballs.

### Description

- Introduce `STATIC_LDFLAGS` (`-static $COMMON_LDFLAGS`) and switch `LDFLAGS` for `haveged`, `rngd` and `jitterentropy-rngd` builds to use the static flags.
- Add `assert_static_binary()` which uses `readelf` to verify no ELF interpreter or shared library `NEEDED` entries, and invoke it for built helpers.
- Change `COREUTILS_VERSION` to `9.9`, add `COREUTILS_HASH` and `COREUTILS_APPLET="stty"`, and validate the downloaded tarball with `sha256sum -c`.
- Adjust coreutils cross-configure/compile settings (set `-std=gnu17`, supply `gl_cv_*` and `ac_cv_*` cache answers, disable many optional features) and build only generated sources then `src/stty` via a small `Makefile` override before copying and stripping the `stty` applet.
- Tweak `jitterentropy-rngd` flags to avoid PIE and use `STATIC_LDFLAGS` while keeping runtime linkers `-lrt -pthread`.

### Testing

- No automated tests were executed as part of this change in the PR; full validation is expected to occur when the updated GitHub Actions nightly workflow runs (verify static binary assertions and cross-builds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b6b5e518483299c961087f79238c6)